### PR TITLE
Add optional serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 thiserror = "1"
+serde = {version = "1.0.123", optional = true, default-features = false}
 
 [dev-dependencies]

--- a/src/bounded_vec.rs
+++ b/src/bounded_vec.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::slice::{Iter, IterMut};
 use std::vec;
@@ -5,6 +7,7 @@ use thiserror::Error;
 
 /// Non-empty Vec bounded with minimal (L - lower bound) and maximal (U - upper bound) items quantity
 #[derive(PartialEq, Eq, Debug, Clone, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(transparent))]
 pub struct BoundedVec<T, const L: usize, const U: usize>
 // enable when feature(const_evaluatable_checked) is stable
 // where


### PR DESCRIPTION
This will be useful for using BoundedVec in sigma-rust. Also, I was wondering, what are your thoughts on adding a try_push function to BoundedVec? It'd make it a bit easier to use, it could return an Option or Result if there's no more room in the vector. 