### PR TITLE
Fix serde support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,36 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./lcov.info
+
+  test_serde:
+    name: Test on ${{ matrix.os }} with serde
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+      - name: Build tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --release --tests --features serde
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --release --features serde
         
   doc-links:
     name: Intra-documentation links

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 thiserror = "1"
+serde = {version = "1.0.123", features = ["derive"], optional = true}
 
 [dev-dependencies]


### PR DESCRIPTION
Seems like a `derive` does not work, failing on bounds for `T`. I've looked at indexmap crate and they have explicitly implemented `Serialize` and `Deserialize`. See  https://github.com/bluss/indexmap/blob/master/src/serde.rs