### PR TITLE
Add no_std support for bounded-vec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,13 +74,20 @@ jobs:
         with:
           command: test
           args: --verbose --release
-      - name: rust-tarpaulin code coverage check
-        if: matrix.os == 'ubuntu-latest'
-        uses: actions-rs/tarpaulin@master
-        with:
-          args: '--timeout=360 -v --out Lcov'
+
+  test_coverage:
+    name: Code coverage in tests
+    runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:latest
+      options: --security-opt seccomp=unconfined
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Generate code coverage
+        run: |
+          cargo tarpaulin --avoid-cfg-tarpaulin --timeout=360 --out lcov
       - name: Push code coverage results to coveralls.io
-        if: matrix.os == 'ubuntu-latest' 
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -115,7 +122,7 @@ jobs:
         with:
           command: test
           args: --verbose --release --all-features
-        
+
   doc-links:
     name: Intra-documentation links
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,16 @@ edition = "2018"
 description = "Non-empty rust Vec wrapper with type guarantees on lower and upper bounds for items quantity."
 repository = "https://github.com/ergoplatform/bounded-vec"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-
 [dependencies]
-thiserror = "1"
-serde = {version = "1.0.123", features = ["derive"], optional = true}
-proptest = {version = "1.0.0", optional = true}
+serde = { version = "1.0.123", default-features = false, features = [
+    "alloc",
+    "derive",
+], optional = true }
+thiserror = { version = "2", default-features = false }
+proptest = { version = "1.0.0", optional = true }
 
 [features]
 arbitrary = ["proptest"]
 
 [dev-dependencies]
-proptest = {version = "1.0.0"}
+proptest = { version = "1.0.0" }

--- a/src/bounded_vec.rs
+++ b/src/bounded_vec.rs
@@ -387,7 +387,7 @@ impl<'a, T, const L: usize, const U: usize> IntoIterator for &'a BoundedVec<T, L
     type IntoIter = core::slice::Iter<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        (&self.inner).iter()
+        self.inner.iter()
     }
 }
 
@@ -396,7 +396,7 @@ impl<'a, T, const L: usize, const U: usize> IntoIterator for &'a mut BoundedVec<
     type IntoIter = core::slice::IterMut<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        (&mut self.inner).iter_mut()
+        self.inner.iter_mut()
     }
 }
 

--- a/src/bounded_vec.rs
+++ b/src/bounded_vec.rs
@@ -1,8 +1,9 @@
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::{TryFrom, TryInto};
+use core::slice::{Iter, IterMut};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::convert::{TryFrom, TryInto};
-use std::slice::{Iter, IterMut};
-use std::vec;
 use thiserror::Error;
 
 /// Non-empty Vec bounded with minimal (L - lower bound) and maximal (U - upper bound) items quantity
@@ -463,7 +464,7 @@ mod arbitrary {
 #[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
-    use std::convert::TryInto;
+    use core::convert::TryInto;
 
     use super::*;
 
@@ -597,6 +598,7 @@ mod tests {
 mod arb_tests {
 
     use super::*;
+    use alloc::format;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! Non-empty Vec wrapper with lower and upper bounds on items quantity
 
+#![no_std]
 // Coding conventions
 #![forbid(unsafe_code)]
 #![deny(non_upper_case_globals)]
@@ -12,6 +13,8 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
+
+extern crate alloc;
 
 mod bounded_vec;
 


### PR DESCRIPTION
Also remove cdylib target as that requires pulling in a global allocator to build for doctests